### PR TITLE
Add swim metrics watch face boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # My Watch Face App
 
 ## Overview
-This project is a custom watch face application designed for Garmin devices. It showcases various features such as displaying time, date, and customizable elements.
+This project is a custom watch face application designed for Garmin devices, specifically targeting the Garmin Swim 2. It showcases features such as displaying time, date, and swimmer-oriented metrics.
 
 ## Project Structure
 - **manifest.xml**: Contains metadata for the watch face application, including app name, version, and permissions.
@@ -23,6 +23,7 @@ This project is a custom watch face application designed for Garmin devices. It 
 
 ## Usage
 Once installed on your Garmin device, you can select this watch face from the device settings. Customize the appearance and functionality as desired.
+The default layout includes heart rate, battery, daily steps, and basic swim metrics like distance swum and lap count.
 
 ## Contributing
 Feel free to submit issues or pull requests if you have suggestions or improvements for the watch face application.

--- a/resources/layouts/layout.xml
+++ b/resources/layouts/layout.xml
@@ -11,6 +11,12 @@
     <!-- Top Right: Battery -->
     <label id="BatteryLabel" x="screen_width-20" y="20" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_RIGHT" color="Graphics.COLOR_GREEN" />
 
-    <!-- Bottom Center: Daily Steps (Example of another metric) -->
+    <!-- Bottom Center: Daily Steps -->
     <label id="StepsLabel" x="center" y="screen_height-40" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_CENTER" color="Graphics.COLOR_BLUE" />
+
+    <!-- Bottom Left: Last Swim Distance -->
+    <label id="SwimDistanceLabel" x="20" y="screen_height-40" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_LEFT" color="Graphics.COLOR_CYAN" />
+
+    <!-- Bottom Right: Lap Count -->
+    <label id="LapCountLabel" x="screen_width-20" y="screen_height-40" font="Graphics.FONT_SMALL" justification="Graphics.TEXT_JUSTIFY_RIGHT" color="Graphics.COLOR_CYAN" />
 </layout>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -4,4 +4,6 @@
     <string name="date_format">EEE, MMM d</string>
     <string name="battery_label">Battery Level:</string>
     <string name="steps_label">Steps:</string>
+    <string name="swim_distance_label">Swim Dist:</string>
+    <string name="lap_count_label">Laps:</string>
 </resources>

--- a/source/MyWatchFaceView.mc
+++ b/source/MyWatchFaceView.mc
@@ -4,6 +4,7 @@ import Toybox.System;
 import Toybox.WatchUi;
 import Toybox.Time.Gregorian;
 import Toybox.ActivityMonitor;
+import Toybox.Swim; // For swim metrics
 import Toybox.Application.Properties;
 
 // This file defines the custom view for the watch face, including the drawing logic and how the time and other elements are rendered.
@@ -15,6 +16,8 @@ class MyWatchFaceView extends WatchUi.WatchFace {
     private var hrLabel as Text?;
     private var batteryLabel as Text?;
     private var stepsLabel as Text?; // Added for steps
+    private var swimDistanceLabel as Text?; // Added for swim distance
+    private var lapCountLabel as Text?; // Added for lap count
 
     // Constructor
     function MyWatchFaceView() {
@@ -34,6 +37,8 @@ class MyWatchFaceView extends WatchUi.WatchFace {
         hrLabel = findDrawableById("HRLabel") as Text;
         batteryLabel = findDrawableById("BatteryLabel") as Text;
         stepsLabel = findDrawableById("StepsLabel") as Text; // Added for steps
+        swimDistanceLabel = findDrawableById("SwimDistanceLabel") as Text;
+        lapCountLabel = findDrawableById("LapCountLabel") as Text;
     }
 
     // Called when this View is brought to the foreground. Restore
@@ -99,6 +104,25 @@ class MyWatchFaceView extends WatchUi.WatchFace {
         }
         if (stepsLabel != null) {
             stepsLabel.setText(stepsText);
+        }
+
+        // Get and show Swim Metrics
+        var distText = "DIST: --";
+        var lapsText = "LAPS: --";
+        var swimInfo = Swim.getInfo();
+        if (swimInfo != null) {
+            if (swimInfo.totalDistance != null) {
+                distText = Lang.format("DIST: $1$m", [swimInfo.totalDistance]);
+            }
+            if (swimInfo.totalLengths != null) {
+                lapsText = Lang.format("LAPS: $1$", [swimInfo.totalLengths]);
+            }
+        }
+        if (swimDistanceLabel != null) {
+            swimDistanceLabel.setText(distText);
+        }
+        if (lapCountLabel != null) {
+            lapCountLabel.setText(lapsText);
         }
 
         // Call the parent onUpdate function to redraw the layout


### PR DESCRIPTION
## Summary
- update README to mention Garmin Swim 2 support
- show swimmer metrics in usage section
- add swim distance and lap count labels
- include swim strings and update layout
- fetch swim metrics in watch face view

## Testing
- `monkeyc` not installed; build skipped

------
https://chatgpt.com/codex/tasks/task_e_6844bae5b74c8327a5b3bcea773cabf8