### PR TITLE
Fix text rendering and document updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,13 @@ All agents working in this repository must log their changes and ideas in this f
   - Any reasoning or context that may help future agents.
 - Keep entries in chronological order and do not remove previous items.
 
+- 120d891: Fixed time/date rendering in `MyWatchFaceApp.mc` and `MyWatchFaceView.mc` and updated documentation. `monkeyc` command not found, so no tests were run.
+
 ## Ideas / Planning
 - Use this section to jot down ideas, future improvements, or notes that may help subsequent agents.
 - Keep items brief, with dates if possible.
+
+- 2025-08-12: Consider improving time/date formatting and adding more robust build instructions.
 
 ## Testing
 - If the project includes tests or build steps, run them after changes. Note results in the change log.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ The default layout includes heart rate, battery, daily steps, and basic swim met
 
 ## Contributing
 Feel free to submit issues or pull requests if you have suggestions or improvements for the watch face application.
+
+## Development Notes
+- Rendering routines were updated to use valid Monkey C `drawText` arguments and built-in font/color constants. This fixes issues where time and date values were not displayed correctly.

--- a/source/MyWatchFaceApp.mc
+++ b/source/MyWatchFaceApp.mc
@@ -19,12 +19,15 @@ class MyWatchFaceApp extends WatchFace {
     function drawTime(dc) {
         // Draw the current time on the watch face
         var time = System.getTime();
-        dc.drawText(time, this.getWidth() / 2, this.getHeight() / 2, Font.DEFAULT, Color.WHITE);
+        dc.setColor(Color.WHITE);
+        dc.drawText(this.getWidth() / 2, this.getHeight() / 2, Font.DEFAULT, time);
     }
 
     function drawDate(dc) {
         // Draw the current date on the watch face
         var date = System.getDate();
-        dc.drawText(date, this.getWidth() / 2, this.getHeight() / 2 + 20, Font.DEFAULT, Color.WHITE);
+        dc.setColor(Color.WHITE);
+        dc.drawText(this.getWidth() / 2, this.getHeight() / 2 + 20, Font.DEFAULT, date);
     }
 }
+

--- a/source/MyWatchFaceView.mc
+++ b/source/MyWatchFaceView.mc
@@ -52,10 +52,11 @@ class MyWatchFaceView extends WatchUi.WatchFace {
         // Clear the background
         graphics.clear();
 
-        // Draw the time
-        var currentTime = System.getTime();
-        var timeString = currentTime.format("HH:mm");
-        graphics.drawText(timeString, 50, 50, "fontName", "color");
+        // Draw the time using a built-in font and color
+        var clockTime = System.getClockTime();
+        var timeString = Lang.format("$1$:$2$", [clockTime.hour.format("%02d"), clockTime.min.format("%02d")]);
+        graphics.setColor(Graphics.COLOR_WHITE);
+        graphics.drawText(50, 50, Graphics.FONT_LARGE, timeString);
 
         // Additional drawing logic for date and other elements can be added here
     }


### PR DESCRIPTION
## Summary
- correct drawText usage in time/date rendering for watch face
- update documentation and log changes for future development

## Testing
- `monkeyc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9d1f6388327ba9b392365a379b0